### PR TITLE
Support patterns and expressions in braced typle_for!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typle"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 description = "Generic tuple bounds and transformations"
 license = "MIT"

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -129,6 +129,13 @@ pub fn evaluate_usize(expr: &Expr) -> Option<usize> {
                     }
                 }
             }
+            syn::BinOp::Div(_) => {
+                if let Some(left) = evaluate_usize(&binary.left) {
+                    if let Some(right) = evaluate_usize(&binary.right) {
+                        return left.checked_div(right);
+                    }
+                }
+            }
             syn::BinOp::Sub(_) => {
                 if let Some(left) = evaluate_usize(&binary.left) {
                     if let Some(right) = evaluate_usize(&binary.right) {
@@ -152,6 +159,9 @@ pub fn evaluate_usize(expr: &Expr) -> Option<usize> {
             }
             _ => {}
         },
+        Expr::Paren(expr) => {
+            return evaluate_usize(&expr.expr);
+        }
         _ => {}
     }
     None

--- a/tests/expand/typle-for.expanded.rs
+++ b/tests/expand/typle-for.expanded.rs
@@ -7,6 +7,7 @@ impl S<()> {
         let a: [u32; 0] = [];
         let b = ();
         let init: [Option<u32>; 0] = [];
+        let c = ();
     }
 }
 impl S<(u32,)> {
@@ -14,6 +15,7 @@ impl S<(u32,)> {
         let a: [u32; 1] = [*t.0 * 2];
         let b = (*t.0 * 2,);
         let init: [Option<u32>; 1] = [None];
+        let c = ({ b.0 },);
     }
 }
 impl S<(u32, u32)> {
@@ -21,5 +23,6 @@ impl S<(u32, u32)> {
         let a: [u32; 2] = [*t.0 * 2, *t.1 * 2];
         let b = (*t.0 * 2, *t.1 * 2);
         let init: [Option<u32>; 2] = [None, None];
+        let c = ({ b.0 },);
     }
 }

--- a/tests/expand/typle-for.rs
+++ b/tests/expand/typle-for.rs
@@ -19,5 +19,7 @@ where
         // Arbitrary expressions can be used for the indices and
         // the iterator variable can be left out if not needed
         let init: [Option<u32>; T::LEN] = typle_for![T::LEN * 2..T::LEN * 3 => None];
+        // const-if can be used to filter components in braced typle_for!
+        let c = typle_for!{i in ..T::LEN => if typle_const!(i % 2 == 0) {b[[i]]}};
     }
 }


### PR DESCRIPTION
A braced expression allows filtering using const-if without an `else` in the expression body.