### PR TITLE
`typle_for!` filtering and `typle_const!` elimination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typle"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2021"
 description = "Generic tuple bounds and transformations"
 license = "MIT"

--- a/tests/compile/doc_typle.rs
+++ b/tests/compile/doc_typle.rs
@@ -71,9 +71,9 @@ mod tuple {
                 #[typle_attr_if(i == 0, allow(unused_variables))]
                 if let Self::State::S::<typle_ident!(i)>(output, inner_state) = state {
                     let matched = self.tuple[[i]].extract(inner_state);
-                    let output = typle_for!(j in ..=i =>
-                        if typle_const!(j < i) { output[[j]] } else { matched }
-                    );
+                    let output = typle_for! {j in ..=i =>
+                        if j < i { output[[j]] } else { matched }
+                    };
                     if typle_const!(i + 1 == T::LEN) {
                         return output;
                     } else {

--- a/tests/expand/typle-for.expanded.rs
+++ b/tests/expand/typle-for.expanded.rs
@@ -8,6 +8,8 @@ impl S<()> {
         let b = ();
         let init: [Option<u32>; 0] = [];
         let c = ();
+        let d = ();
+        let e = [];
     }
 }
 impl S<(u32,)> {
@@ -16,6 +18,8 @@ impl S<(u32,)> {
         let b = (*t.0 * 2,);
         let init: [Option<u32>; 1] = [None];
         let c = ({ b.0 },);
+        let d = ({ b.0 },);
+        let e = [{ b.0 }];
     }
 }
 impl S<(u32, u32)> {
@@ -24,5 +28,7 @@ impl S<(u32, u32)> {
         let b = (*t.0 * 2, *t.1 * 2);
         let init: [Option<u32>; 2] = [None, None];
         let c = ({ b.0 },);
+        let d = ({ b.0 },);
+        let e = [{ b.0 }];
     }
 }

--- a/tests/expand/typle-for.rs
+++ b/tests/expand/typle-for.rs
@@ -19,7 +19,10 @@ where
         // Arbitrary expressions can be used for the indices and
         // the iterator variable can be left out if not needed
         let init: [Option<u32>; T::LEN] = typle_for![T::LEN * 2..T::LEN * 3 => None];
-        // const-if can be used to filter components in braced typle_for!
-        let c = typle_for!{i in ..T::LEN => if typle_const!(i % 2 == 0) {b[[i]]}};
+        // const-if can be used to filter components in `typle_for!`. Braces
+        // always use const-if.
+        let c = typle_for!(i in ..T::LEN => if typle_const!(i == 0) {b[[i]]});
+        let d = typle_for!{i in ..T::LEN => if i == 0 {b[[i]]}};
+        let e = typle_for![i in ..T::LEN => if typle_const!(i == 0) {b[[i]]}];
     }
 }


### PR DESCRIPTION
For all `typle_for!` delimiters, if a const-if expression is false and there is no else clause, omit the component from the output.

For `typle_for!` with braces, treat all `if` expressions as const.