### PR TITLE
Support multiple values from each iteration of `typle!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Backwards-incompatible changes
 - `typle_bounds!` has been replaced by support for `typle!` macro in where clauses.
+- `typle_args` as a synonym for `typle!` has been removed.
 
 # 0.11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 either = "1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2.0.43", features = ["full", "extra-traits"] }
+syn = { version = "2.0.43", features = ["full", "parsing"] }
 zip_clone = "0.1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ For example, to define a function to zip a pair of tuples into a tuple of pairs:
 pub fn zip<A: Tuple, B: Tuple>(
     a: A,
     b: B,
-) -> (typle![i in .. => (A<{i}>, B<{i}>)])
+) -> (typle! {
+    i in .. => (A<{i}>, B<{i}>)
+})
 {
-    (typle!{i in .. => (a[[i]], b[[i]])})
+    (typle! {
+        i in .. => (a[[i]], b[[i]])
+    })
 }
 ```
 
@@ -61,7 +65,7 @@ where
     T: Tuple,           // `T`` is a tuple with 0 to 3 components.
     T<_>: HandleStuff,  // All components implement `HandleStuff`.
 {
-    type Output = (typle!(i in .. => T<{i}>::Output));
+    type Output = (typle! {i in .. => T<{i}>::Output});
 
     // Return a tuple of output from each handler applied to the same input.
     fn handle_stuff(&self, input: Input) -> Self::Output {
@@ -69,7 +73,9 @@ where
             ()
         } else {
             (
-                typle!(i in ..T::LAST => self.handlers[[i]].handle_stuff(input.clone())),
+                typle! {
+                    i in ..T::LAST => self.handlers[[i]].handle_stuff(input.clone())
+                },
                 // Avoid expensive clone for the last handler.
                 self.handlers[[T::LAST]].handle_stuff(input),
             )
@@ -90,7 +96,7 @@ impl<T0> HandleStuff for MultipleHandlers<(T0,)>
 where
     T0: HandleStuff,
 {
-    type Output = (<T0>::Output,);
+    type Output = (T0::Output,);
     fn handle_stuff(&self, input: Input) -> Self::Output {
         { (self.handlers.0.handle_stuff(input),) }
     }
@@ -100,7 +106,7 @@ where
     T0: HandleStuff,
     T1: HandleStuff,
 {
-    type Output = (<T0>::Output, <T1>::Output);
+    type Output = (T0::Output, T1::Output);
     fn handle_stuff(&self, input: Input) -> Self::Output {
         {
             (
@@ -116,7 +122,7 @@ where
     T1: HandleStuff,
     T2: HandleStuff,
 {
-    type Output = (<T0>::Output, <T1>::Output, <T2>::Output);
+    type Output = (T0::Output, T1::Output, T2::Output);
     fn handle_stuff(&self, input: Input) -> Self::Output {
         {
             (

--- a/src/context/pat.rs
+++ b/src/context/pat.rs
@@ -119,13 +119,13 @@ impl TypleContext {
         match &mut pat {
             Pat::Macro(syn::PatMacro { mac, .. }) => {
                 if let Some(ident) = mac.path.get_ident() {
-                    if ident == "typle" || ident == "typle_args" {
+                    if ident == "typle" {
                         let token_stream = std::mem::take(&mut mac.tokens);
                         return self.expand_typle_macro(token_stream, |context, token_stream| {
                             let mut pat = Pat::parse_single.parse2(token_stream)?;
                             let mut state = BlockState::default();
                             context.replace_pat(&mut pat, &mut state)?;
-                            Ok(pat)
+                            Ok(Replacements::<std::iter::Empty<_>>::Singleton(Ok(pat)))
                         });
                     }
                 }

--- a/tests/compile/doc_typle.rs
+++ b/tests/compile/doc_typle.rs
@@ -62,8 +62,13 @@ mod tuple {
         T: Tuple,
         T<_>: Extract,
     {
-        S = typle_variant!(i in ..T::MAX =>
-            (typle!(j in ..i => T::<{j}>::Output)), Option<T<{i}>::State>
+        S = typle_variant!(
+            curr in ..T::MAX => (
+                typle! {
+                    prev in ..curr => T::<{prev}>::Output
+                }
+            ),
+            Option<T<{curr}>::State>
         ),
     }
 
@@ -79,7 +84,7 @@ mod tuple {
         // The state contains the output from all previous components and the state
         // of the current component.
         type State = TupleSequenceState<T<{ ..T::MAX }>>;
-        type Output = (typle!(i in .. => <T<{i}> as Extract>::Output));
+        type Output = (typle! {i in .. => <T<{i}> as Extract>::Output});
 
         fn extract(&self, state: Option<Self::State>) -> Self::Output {
             #[typle_attr_if(T::LEN == 1, allow(unused_mut))]

--- a/tests/compile/mod.expanded.rs
+++ b/tests/compile/mod.expanded.rs
@@ -2380,6 +2380,139 @@ pub mod pattern {
         <(T, u32) as _typle_fn_multiply_by>::apply((t, m))
     }
 }
+pub mod spread {
+    use std::ops::{Add, Mul};
+    use typle::typle;
+    #[allow(non_camel_case_types)]
+    trait _typle_fn_duplicate_components {
+        type Return;
+        fn apply(self) -> Self::Return;
+    }
+    impl _typle_fn_duplicate_components for ((),) {
+        type Return = ();
+        fn apply(self) -> Self::Return {
+            #[allow(unused_variables)]
+            let (t,) = self;
+            { () }
+        }
+    }
+    impl<T0> _typle_fn_duplicate_components for ((T0,),)
+    where
+        T0: Clone,
+    {
+        type Return = (T0, T0);
+        fn apply(self) -> Self::Return {
+            let (t,) = self;
+            { (t.0.clone(), t.0) }
+        }
+    }
+    impl<T0, T1> _typle_fn_duplicate_components for ((T0, T1),)
+    where
+        T0: Clone,
+        T1: Clone,
+    {
+        type Return = (T0, T0, T1, T1);
+        fn apply(self) -> Self::Return {
+            let (t,) = self;
+            { (t.0.clone(), t.0, t.1.clone(), t.1) }
+        }
+    }
+    impl<T0, T1, T2> _typle_fn_duplicate_components for ((T0, T1, T2),)
+    where
+        T0: Clone,
+        T1: Clone,
+        T2: Clone,
+    {
+        type Return = (T0, T0, T1, T1, T2, T2);
+        fn apply(self) -> Self::Return {
+            let (t,) = self;
+            { (t.0.clone(), t.0, t.1.clone(), t.1, t.2.clone(), t.2) }
+        }
+    }
+    fn duplicate_components<T>(t: T) -> <(T,) as _typle_fn_duplicate_components>::Return
+    where
+        (T,): _typle_fn_duplicate_components,
+    {
+        <(T,) as _typle_fn_duplicate_components>::apply((t,))
+    }
+    #[allow(non_camel_case_types)]
+    trait _typle_fn_sum_and_product {
+        type Return;
+        fn apply(self) -> Self::Return;
+    }
+    impl _typle_fn_sum_and_product for ((), ()) {
+        type Return = ();
+        fn apply(self) -> Self::Return {
+            #[allow(unused_variables)]
+            let (s, t) = self;
+            { () }
+        }
+    }
+    impl<S0, T0> _typle_fn_sum_and_product for ((S0,), (T0,))
+    where
+        S0: Copy,
+        T0: Copy,
+        S0: Add<T0> + Mul<T0>,
+    {
+        type Return = (<S0 as Add<T0>>::Output, <S0 as Mul<T0>>::Output);
+        fn apply(self) -> Self::Return {
+            let (s, t) = self;
+            { (s.0 + t.0, s.0 * t.0) }
+        }
+    }
+    impl<S0, S1, T0, T1> _typle_fn_sum_and_product for ((S0, S1), (T0, T1))
+    where
+        S0: Copy,
+        S1: Copy,
+        T0: Copy,
+        T1: Copy,
+        S0: Add<T0> + Mul<T0>,
+        S1: Add<T1> + Mul<T1>,
+    {
+        type Return = (
+            <S0 as Add<T0>>::Output,
+            <S0 as Mul<T0>>::Output,
+            <S1 as Add<T1>>::Output,
+            <S1 as Mul<T1>>::Output,
+        );
+        fn apply(self) -> Self::Return {
+            let (s, t) = self;
+            { (s.0 + t.0, s.0 * t.0, s.1 + t.1, s.1 * t.1) }
+        }
+    }
+    impl<S0, S1, S2, T0, T1, T2> _typle_fn_sum_and_product
+    for ((S0, S1, S2), (T0, T1, T2))
+    where
+        S0: Copy,
+        S1: Copy,
+        S2: Copy,
+        T0: Copy,
+        T1: Copy,
+        T2: Copy,
+        S0: Add<T0> + Mul<T0>,
+        S1: Add<T1> + Mul<T1>,
+        S2: Add<T2> + Mul<T2>,
+    {
+        type Return = (
+            <S0 as Add<T0>>::Output,
+            <S0 as Mul<T0>>::Output,
+            <S1 as Add<T1>>::Output,
+            <S1 as Mul<T1>>::Output,
+            <S2 as Add<T2>>::Output,
+            <S2 as Mul<T2>>::Output,
+        );
+        fn apply(self) -> Self::Return {
+            let (s, t) = self;
+            { (s.0 + t.0, s.0 * t.0, s.1 + t.1, s.1 * t.1, s.2 + t.2, s.2 * t.2) }
+        }
+    }
+    fn sum_and_product<S, T>(s: S, t: T) -> <(S, T) as _typle_fn_sum_and_product>::Return
+    where
+        (S, T): _typle_fn_sum_and_product,
+    {
+        <(S, T) as _typle_fn_sum_and_product>::apply((s, t))
+    }
+}
 pub mod type_alias {
     #![allow(type_alias_bounds, unused)]
     use typle::typle;

--- a/tests/compile/mod.rs
+++ b/tests/compile/mod.rs
@@ -7,6 +7,7 @@ pub mod issue1;
 pub mod macros;
 pub mod method;
 pub mod pattern;
+pub mod spread;
 pub mod type_alias;
 pub mod typle_args;
 pub mod typle_fold;

--- a/tests/compile/spread.rs
+++ b/tests/compile/spread.rs
@@ -1,0 +1,30 @@
+use std::ops::{Add, Mul};
+
+use typle::typle;
+
+#[typle(Tuple for 0..=3)]
+fn duplicate_components<T: Tuple>(
+    t: T,
+) -> (typle! {
+        i in .. => T<{i}>, T<{i}>
+    })
+where
+    T<_>: Clone,
+{
+    (typle! {
+        i in .. => t[[i]].clone(), t[[i]]
+    })
+}
+
+#[typle(Tuple for 0..=3)]
+fn sum_and_product<S: Tuple, T: Tuple>(
+    s: S,
+    t: T,
+) -> (typle! {i in .. => <S<{i}> as Add<T<{i}>>>::Output, <S<{i}> as Mul<T<{i}>>>::Output})
+where
+    S<_>: Copy,
+    T<_>: Copy,
+    typle!(i in .. => S<{i}>: Add<T<{i}>> + Mul<T<{i}>>): Tuple::Bounds,
+{
+    (typle! {i in .. => s[[i]] + t[[i]], s[[i]] * t[[i]]})
+}

--- a/tests/compile/typle_args.rs
+++ b/tests/compile/typle_args.rs
@@ -94,7 +94,7 @@ where
     T: Tuple,          // `T`` is a tuple with 0 to 3 components.
     T<_>: HandleStuff, // All components implement `HandleStuff`.
 {
-    type Output = (typle!(i in .. => T<{i}>::Output));
+    type Output = (typle! {i in .. => T<{i}>::Output});
 
     // Return a tuple of output from each handler applied to the same input.
     fn handle_stuff(&self, input: Input) -> Self::Output {
@@ -102,7 +102,9 @@ where
             ()
         } else {
             (
-                typle!(i in ..T::LAST => self.handlers[[i]].handle_stuff(input.clone())),
+                typle! {
+                    i in ..T::LAST => self.handlers[[i]].handle_stuff(input.clone())
+                },
                 // Avoid expensive clone for the last handler.
                 self.handlers[[T::LAST]].handle_stuff(input),
             )


### PR DESCRIPTION
```
(typle! {i in .. => T<{i}>, T<{i}>})
(typle! {i in .. => t[[i]], t[[i]]})
(typle! {i in .. => T<{i}>: Add<S<{i}>> + Mul<S<{i}>>}): Tuple::Bounds
```