### PR TITLE
Allow no-range `typle!` macro in singleton position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.13
+
+## Backwards-incompatible changes
+- Remove `typle_for!`. Use `typle!`.
+
+## Other changes
+- Allow `typle!` macro with no range in singleton position.
+
 # 0.12
 
 ## Backwards-incompatible changes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,35 @@
 //! assert_eq!(even_to_string((0, vec![1], 2, 3)), ("0".to_owned(), vec![1], "2".to_owned(), 3));
 //! ```
 //!
+//! The `typle!` macro can appear outside a comma-separated sequence if it has no range. This will
+//! replace the single value at the position. This can be used to add an `if` statement where
+//! expressions are otherwise invalid:
+//!
+//! ```rust
+//! # use typle::typle;
+//! # struct MyStruct<T> {
+//! #     t: T,
+//! # }
+//! trait Trait {
+//!     type Input;
+//!     type Output;
+//!     fn method(&self, input: Self::Input) -> Self::Output;
+//! }
+//!
+//! #[typle(Tuple for 0..=3)]
+//! impl<T: Tuple> Trait for MyStruct<T> {
+//!     type Input = typle!(=> if T::LEN == 0 { () } else { T<{0}> });
+//!     type Output = typle!(=> if T::LEN == 0 { () } else { T<{0}> });
+//!
+//!     fn method(
+//!         &self,
+//!         input: typle!(=> if T::LEN == 0 { () } else { T<{0}>}),
+//!     ) -> typle!(=> if T::LEN == 0 { () } else { T<{0}> }) {
+//!         typle!(=> if T::LEN == 0 { () } else { input })
+//!     }
+//! }
+//! ```
+//!
 //! The `typle_const!` macro supports const-if on a boolean typle index expression. const-if allows
 //! conditional branches that do not compile, as long as the invalid branch is `false` at compile time.
 //!

--- a/tests/compile/conditional.rs
+++ b/tests/compile/conditional.rs
@@ -1,0 +1,28 @@
+#![allow(unused)]
+
+use typle::typle;
+
+trait Trait {
+    type Input;
+    type Output;
+
+    fn method(&self, input: Self::Input) -> Self::Output;
+}
+
+struct MyStruct<T> {
+    t: T,
+}
+
+#[typle(Tuple for 0..=3)]
+#[typle_attr_if(T::LEN == 1, rustfmt::skip)]
+impl<T: Tuple> Trait for MyStruct<T> {
+    type Input = typle!(=> if T::LEN == 0 { () } else { T<{0}> });
+    type Output = typle!(=> if T::LEN == 0 { () } else { T<{0}> });
+
+    fn method(
+        &self,
+        input: typle!(=> if T::LEN == 0 { () } else { T<{0}>}),
+    ) -> typle!(=> if T::LEN == 0 { () } else { T<{0}> }) {
+        typle!(=> if T::LEN == 0 { () } else { input })
+    }
+}

--- a/tests/compile/mod.expanded.rs
+++ b/tests/compile/mod.expanded.rs
@@ -1,3 +1,44 @@
+pub mod conditional {
+    #![allow(unused)]
+    use typle::typle;
+    trait Trait {
+        type Input;
+        type Output;
+        fn method(&self, input: Self::Input) -> Self::Output;
+    }
+    struct MyStruct<T> {
+        t: T,
+    }
+    impl Trait for MyStruct<()> {
+        type Input = ();
+        type Output = ();
+        fn method(&self, input: ()) -> () {
+            ()
+        }
+    }
+    #[rustfmt::skip]
+    impl<T0> Trait for MyStruct<(T0,)> {
+        type Input = T0;
+        type Output = T0;
+        fn method(&self, input: T0) -> T0 {
+            input
+        }
+    }
+    impl<T0, T1> Trait for MyStruct<(T0, T1)> {
+        type Input = T0;
+        type Output = T0;
+        fn method(&self, input: T0) -> T0 {
+            input
+        }
+    }
+    impl<T0, T1, T2> Trait for MyStruct<(T0, T1, T2)> {
+        type Input = T0;
+        type Output = T0;
+        fn method(&self, input: T0) -> T0 {
+            input
+        }
+    }
+}
 pub mod const_generic {
     #![allow(dead_code)]
     use typle::typle;

--- a/tests/compile/mod.rs
+++ b/tests/compile/mod.rs
@@ -1,3 +1,4 @@
+pub mod conditional;
 pub mod const_generic;
 pub mod doc_typle;
 pub mod for_loop;

--- a/tests/expand/typle-for.rs
+++ b/tests/expand/typle-for.rs
@@ -1,8 +1,7 @@
 use typle::typle;
 
-struct S<T>
-{
-    t: T
+struct S<T> {
+    t: T,
 }
 
 #[typle(Tuple for 0..=2)]
@@ -10,16 +9,16 @@ impl<T> S<T>
 where
     T: Tuple<u32>,
 {
-    fn new(t: typle_for!(i in .. => &T<{i}>)) {
+    fn new(t: (typle! {i in .. => &T<{i}>})) {
         // Square brackets create an array
         let a: [u32; T::LEN] = [typle!(i in .. => *t[[i]] * 2)];
         // Parentheses create a tuple
         // The default bounds of the range are 0..Tuple::LEN
-        let b = typle_for!(i in .. => *t[[i]] * 2);
+        let b = (typle!(i in .. => *t[[i]] * 2));
         // Arbitrary expressions can be used for the indices and
         // the iterator variable can be left out if not needed
         let init: [Option<u32>; T::LEN] = [typle!(T::LEN * 2..T::LEN * 3 => None)];
         // const-if can be used to filter components in `typle_for!`.
-        let c = typle_for!(i in .. => if i == 0 {b[[i]]});
+        let c = (typle!(i in .. => if i == 0 {b[[i]]}));
     }
 }


### PR DESCRIPTION
Remove `typle_for!` macro.